### PR TITLE
Add an example DTS for the HiFive Unleashed

### DIFF
--- a/examples/sifive-hifive_unleashed-microsemi.dts
+++ b/examples/sifive-hifive_unleashed-microsemi.dts
@@ -1,0 +1,622 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <2>;
+	#size-cells = <2>;
+	compatible = "sifive,fu540g", "sifive,fu500";
+	model = "sifive,hifive-unleashed-a00";
+
+	aliases {
+		serial0 = &L28;
+		serial1 = &L29;
+	};
+
+	chosen {
+	};
+
+	firmware {
+		sifive,fsbl = "YYYY-MM-DD";
+	};
+
+	L3: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		timebase-frequency = <1000000>;
+		L9: cpu@0 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <128>;
+			i-cache-size = <16384>;
+			next-level-cache = <&L24 &L0>;
+			reg = <0>;
+			riscv,isa = "rv64imac";
+			sifive,dtim = <&L8>;
+			sifive,itim = <&L7>;
+			status = "okay";
+			L10: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+		L12: cpu@1 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <32768>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <32>;
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <32768>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <32>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L24 &L0>;
+			reg = <1>;
+			riscv,isa = "rv64imafdc";
+			sifive,itim = <&L11>;
+			status = "okay";
+			tlb-split;
+			L13: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+		L15: cpu@2 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <32768>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <32>;
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <32768>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <32>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L24 &L0>;
+			reg = <2>;
+			riscv,isa = "rv64imafdc";
+			sifive,itim = <&L14>;
+			status = "okay";
+			tlb-split;
+			L16: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+		L18: cpu@3 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <32768>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <32>;
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <32768>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <32>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L24 &L0>;
+			reg = <3>;
+			riscv,isa = "rv64imafdc";
+			sifive,itim = <&L17>;
+			status = "okay";
+			tlb-split;
+			L19: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+		L21: cpu@4 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <32768>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <32>;
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <32768>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <32>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L24 &L0>;
+			reg = <4>;
+			riscv,isa = "rv64imafdc";
+			sifive,itim = <&L20>;
+			status = "okay";
+			tlb-split;
+			L22: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L36: memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0x1f 0x80000000>;
+	};
+	L2: soc {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		compatible = "SiFive,FU540G-soc", "fu500-soc", "sifive-soc", "simple-bus";
+		ranges;
+		refclk: refclk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <33333333>;
+			clock-output-names = "xtal";
+		};
+		prci: prci@10000000 {
+			compatible = "sifive,ux00prci0";
+			reg = <0x0 0x10000000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&refclk>;
+			#clock-cells = <1>;
+		};
+		tlclk: tlclk {
+			compatible = "fixed-factor-clock";
+			clocks = <&prci 0>;
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clock-mult = <1>;
+		};
+		L51: cadence-gemgxl-mgmt@100a0000 {
+			compatible = "sifive,cadencegemgxlmgmt0";
+			reg = <0x0 0x100a0000 0x0 0x1000>;
+			reg-names = "control";
+			#clock-cells = <0>;
+		};
+		L35: bus-blocker@100b8000 {
+			compatible = "sifive,bus-blocker0";
+			reg = <0x0 0x100b8000 0x0 0x1000>;
+			reg-names = "control";
+		};
+		L0: cache-controller@2010000 {
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-sets = <2048>;
+			cache-size = <2097152>;
+			cache-unified;
+			compatible = "sifive,ccache0", "cache";
+			interrupt-parent = <&L4>;
+			interrupts = <1 2 3>;
+			next-level-cache = <&L25 &L40 &L36>;
+			reg = <0x0 0x2010000 0x0 0x1000 0x0 0x8000000 0x0 0x2000000>;
+			reg-names = "control", "sideband";
+		};
+		L33: cadence-ddr-mgmt@100c0000 {
+			compatible = "sifive,cadenceddrmgmt0";
+			reg = <0x0 0x100c0000 0x0 0x1000>;
+			reg-names = "control";
+		};
+		L40: chiplink@40000000 {
+			#address-cells = <2>;
+			#size-cells = <2>;
+			compatible = "sifive,chiplink", "simple-bus";
+			ranges = <0x0 0x60000000 0x0 0x60000000 0x0 0x20000000 0x30 0x0 0x30 0x0 0x10 0x0 0x0 0x40000000 0x0 0x40000000 0x0 0x20000000 0x20 0x0 0x20 0x0 0x10 0x0>;
+		};
+		L5: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L10 3 &L10 7 &L13 3 &L13 7 &L16 3 &L16 7 &L19 3 &L19 7 &L22 3 &L22 7>;
+			reg = <0x0 0x2000000 0x0 0x10000>;
+			reg-names = "control";
+		};
+		L6: debug-controller@0 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			interrupts-extended = <&L10 65535 &L13 65535 &L16 65535 &L19 65535 &L22 65535>;
+			reg = <0x0 0x0 0x0 0x1000>;
+			reg-names = "control";
+		};
+		L32: dma@3000000 {
+			#dma-cells = <1>;
+			compatible = "riscv,dma0";
+			dma-channels = <4>;
+			dma-requests = <0>;
+			interrupt-parent = <&L4>;
+			interrupts = <23 24 25 26 27 28 29 30>;
+			reg = <0x0 0x3000000 0x0 0x100000>;
+			reg-names = "control";
+			riscv,dma-pools = <1>;
+		};
+		L8: dtim@1000000 {
+			compatible = "sifive,dtim0";
+			reg = <0x0 0x1000000 0x0 0x2000>;
+			reg-names = "mem";
+		};
+		L44: ememoryotp@10070000 {
+			compatible = "sifive,ememoryotp0";
+			reg = <0x0 0x10070000 0x0 0x1000>;
+			reg-names = "control";
+		};
+		L24: error-device@18000000 {
+			compatible = "sifive,error0";
+			reg = <0x0 0x18000000 0x0 0x8000000>;
+			reg-names = "mem";
+		};
+		L52: ethernet@10090000 {
+			compatible = "cdns,macb";
+			interrupt-parent = <&L4>;
+			interrupts = <53>;
+			reg = <0x0 0x10090000 0x0 0x2000>;
+			reg-names = "control";
+
+			local-mac-address = [00 00 00 00 00 00];
+			phy-mode = "gmii";
+			clock-names = "pclk", "hclk", "tx_clk";
+			clocks = <&prci 1>, <&prci 1>, <&L51>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+			phy1: ethernet-phy@0 {
+				reg = <0>;
+				reset-gpios = <&L31 12 1>;
+			};
+		};
+		L31: gpio@10060000 {
+			compatible = "sifive,gpio0";
+			interrupt-parent = <&L4>;
+			interrupts = <7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22>;
+			reg = <0x0 0x10060000 0x0 0x1000>;
+			reg-names = "control";
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupt-controller;
+			#interrupt-cells = <2>;
+		};
+		gpio-restart {
+			compatible = "gpio-restart";
+			gpios = <&L31 10 1>;
+		};
+		L47: i2c@10030000 {
+			compatible = "sifive,i2c0", "opencores,i2c-ocores";
+			reg = <0x0 0x10030000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+
+			reg-shift = <2>;
+			reg-io-width = <1>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			/* On pre-production boards only */
+/*
+			ina233-vdd_soc_core@40 {
+				compatible = "ti,pmbus";
+				reg = <0x40>;
+			};
+			ina233-vdd_ddr_soc@44 {
+				compatible = "ti,pmbus";
+				reg = <0x44>;
+			};
+			ina233-vdd_ddr_mem@45 {
+				compatible = "ti,pmbus";
+				reg = <0x45>;
+			};
+			ina233-vdd_corepll@47 {
+				compatible = "ti,pmbus";
+				reg = <0x47>;
+			};
+			ina233-vdd_otp@4a {
+				compatible = "ti,pmbus";
+				reg = <0x4a>;
+			};
+			ina233-vdd_io@4b {
+				compatible = "ti,pmbus";
+				reg = <0x4b>;
+			};
+			ina233-vdd_ddrpll@48 {
+				compatible = "ti,pmbus";
+				reg = <0x48>;
+			};
+			ina233-avdd_ddrpll@49 {
+				compatible = "ti,pmbus";
+				reg = <0x49>;
+			};
+			ina233-vdd_givdd@4c {
+				compatible = "ti,pmbus";
+				reg = <0x4c>;
+			};
+			ina233vdd_gemgxlpll@4d {
+				compatible = "ti,pmbus";
+				reg = <0x4d>;
+			};
+*/
+			/* On the tester board */
+/*
+			m24c02 {
+				compatible = "st,24c02";
+				reg = <0x51>;
+			};
+*/
+		};
+		L4: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L10 11 &L13 11 &L13 9 &L16 11 &L16 9 &L19 11 &L19 9 &L22 11 &L22 9>;
+			reg = <0x0 0xc000000 0x0 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <7>;
+			riscv,ndev = <53>;
+		};
+		L7: itim@1800000 {
+			compatible = "sifive,itim0";
+			reg = <0x0 0x1800000 0x0 0x4000>;
+			reg-names = "mem";
+		};
+		L11: itim@1808000 {
+			compatible = "sifive,itim0";
+			reg = <0x0 0x1808000 0x0 0x8000>;
+			reg-names = "mem";
+		};
+		L14: itim@1810000 {
+			compatible = "sifive,itim0";
+			reg = <0x0 0x1810000 0x0 0x8000>;
+			reg-names = "mem";
+		};
+		L17: itim@1818000 {
+			compatible = "sifive,itim0";
+			reg = <0x0 0x1818000 0x0 0x8000>;
+			reg-names = "mem";
+		};
+		L20: itim@1820000 {
+			compatible = "sifive,itim0";
+			reg = <0x0 0x1820000 0x0 0x8000>;
+			reg-names = "mem";
+		};
+		L37: memory-controller@100b0000 {
+			compatible = "sifive,ux00ddr0";
+			interrupt-parent = <&L4>;
+			interrupts = <31>;
+			reg = <0x0 0x100b0000 0x0 0x4000>;
+			reg-names = "control";
+		};
+		pci@2000000000 {
+			#address-cells = <3>;
+			#interrupt-cells = <1>;
+			#size-cells = <2>;
+			compatible = "xlnx,axi-pcie-host-1.00.a";
+			device_type = "pci";
+			interrupt-map = <0 0 0 1 &xil_pcie_intc 1 0 0 0 2 &xil_pcie_intc 2 0 0 0 3 &xil_pcie_intc 3 0 0 0 4 &xil_pcie_intc 4>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-parent = <&L4>;
+			interrupts = <32>;
+			ranges = <0x2000000 0x0 0x40000000 0x0 0x40000000 0x0 0x20000000>;
+			reg = <0x020 0x0 0x0 0x4000000>;
+			reg-names = "control";
+			xil_pcie_intc: interrupt-controller {
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		pci@2030000000 {
+			#address-cells = <3>;
+			#interrupt-cells = <1>;
+			#size-cells = <2>;
+			compatible = "ms-pf,axi-pcie-host";
+			device_type = "pci";
+			bus-range = <0x01 0x7f>;
+			interrupt-map = <0 0 0 1 &ms_pcie_intc 1 0 0 0 2 &ms_pcie_intc 2 0 0 0 3 &ms_pcie_intc 3 0 0 0 4 &ms_pcie_intc 4>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-parent = <&L4>;
+			interrupts = <32>;
+			ranges = <0x2000000 0x0 0x40000000 0x0 0x40000000 0x0 0x20000000>;
+			reg = <0x20 0x30000000 0x0 0x4000000 0x20 0x0 0x0 0x100000>;
+			reg-names = "control", "apb";
+			ms_pcie_intc: interrupt-controller {
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		L53: pinctrl@10080000 {
+			compatible = "sifive,pinctrl0";
+			reg = <0x0 0x10080000 0x0 0x1000>;
+			reg-names = "control";
+		};
+		L45: pwm@10020000 {
+			compatible = "sifive,pwm0";
+			interrupt-parent = <&L4>;
+			interrupts = <42 43 44 45>;
+			reg = <0x0 0x10020000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+			sifive,approx-period = <1000000>;
+			#pwm-cells = <2>;
+		};
+		L46: pwm@10021000 {
+			compatible = "sifive,pwm0";
+			interrupt-parent = <&L4>;
+			interrupts = <46 47 48 49>;
+			reg = <0x0 0x10021000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+			sifive,approx-period = <1000000>;
+			#pwm-cells = <2>;
+		};
+		pwmleds {
+			compatible = "pwm-leds";
+			heartbeat {
+				pwms = <&L45 0 0>;
+				max-brightness = <255>;
+				linux,default-trigger = "heartbeat";
+			};
+			mtd {
+				pwms = <&L45 1 0>;
+				max-brightness = <255>;
+				linux,default-trigger = "mtd";
+			};
+			netdev {
+				pwms = <&L45 2 0>;
+				max-brightness = <255>;
+				linux,default-trigger = "netdev";
+			};
+			panic {
+				pwms = <&L45 3 0>;
+				max-brightness = <255>;
+				linux,default-trigger = "panic";
+			};
+			/* These LEDs are on the tester board */
+/*
+			testled {
+				pwms = <&L46 0 0>;
+				max-brightness = <255>;
+			};
+			green {
+				pwms = <&L46 1 0>;
+				max-brightness = <255>;
+			};
+			red {
+				pwms = <&L46 2 0>;
+				max-brightness = <255>;
+			};
+			blue {
+				pwms = <&L46 3 0>;
+				max-brightness = <255>;
+			};
+*/
+		};
+		L27: rom@1000 {
+			compatible = "sifive,modeselect0";
+			reg = <0x0 0x1000 0x0 0x1000>;
+			reg-names = "mem";
+		};
+		L26: rom@10000 {
+			compatible = "sifive,maskrom0";
+			reg = <0x0 0x10000 0x0 0x8000>;
+			reg-names = "mem";
+		};
+		L25: rom@a000000 {
+			compatible = "ucbbar,cacheable-zero0";
+			reg = <0x0 0xa000000 0x0 0x2000000>;
+			reg-names = "mem";
+		};
+		L28: serial@10010000 {
+			compatible = "sifive,uart0";
+			interrupt-parent = <&L4>;
+			interrupts = <4>;
+			reg = <0x0 0x10010000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+		};
+		L29: serial@10011000 {
+			compatible = "sifive,uart0";
+			interrupt-parent = <&L4>;
+			interrupts = <5>;
+			reg = <0x0 0x10011000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+		};
+		L49: spi@10040000 {
+			compatible = "sifive,spi0";
+			interrupt-parent = <&L4>;
+			interrupts = <51>;
+			reg = <0x0 0x10040000 0x0 0x1000 0x0 0x20000000 0x0 0x10000000>;
+			reg-names = "control", "mem";
+			clocks = <&tlclk>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+			flash@0 {
+				compatible = "issi,is25wp256d", "jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <50000000>;
+				m25p,fast-read;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
+			};
+		};
+		L50: spi@10041000 {
+			compatible = "sifive,spi0";
+			interrupt-parent = <&L4>;
+			interrupts = <52>;
+			reg = <0x0 0x10041000 0x0 0x1000 0x0 0x30000000 0x0 0x10000000>;
+			reg-names = "control", "mem";
+			clocks = <&tlclk>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			/* These flash chips are on the tester board */
+/*
+			flash@0 {
+				compatible = "issi,is25wp032", "jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <25000000>;
+				m25p,fast-read;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
+			};
+			flash@1 {
+				compatible = "issi,is25wp032", "jedec,spi-nor";
+				reg = <1>;
+				spi-max-frequency = <25000000>;
+				m25p,fast-read;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
+			};
+			flash@2 {
+				compatible = "issi,is25wp032", "jedec,spi-nor";
+				reg = <2>;
+				spi-max-frequency = <25000000>;
+				m25p,fast-read;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
+			};
+			flash@3 {
+				compatible = "issi,is25wp032", "jedec,spi-nor";
+				reg = <3>;
+				spi-max-frequency = <25000000>;
+				m25p,fast-read;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
+			};
+*/
+		};
+		L30: spi@10050000 {
+			compatible = "sifive,spi0";
+			interrupt-parent = <&L4>;
+			interrupts = <6>;
+			reg = <0x0 0x10050000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+			mmc@0 {
+				compatible = "mmc-spi-slot";
+				reg = <0>;
+				spi-max-frequency = <20000000>;
+				voltage-ranges = <3300 3300>;
+				disable-wp;
+				gpios = <&L31 11 1>;
+			};
+		};
+		L23: teststatus@4000 {
+			compatible = "sifive,test0";
+			reg = <0x0 0x4000 0x0 0x1000>;
+			reg-names = "control";
+		};
+	};
+};


### PR DESCRIPTION
This is the device tree that's shipped on the HiFive Unleashed, where it
lives inside the FSBL (which is in a SPI flash).  As that's the only
currently availiable RISC-V Linux board it should serve as a good
reference for people who want to poke around in device tree land.

This device tree contains entries that coorespond to devices on the
MicroSemi expansion board.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>