### PR TITLE
vendor-prefixes.txt is now a .yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ node.
   use the same file name and relative path.
 - If your binding is not present in Linux, add its name (including the path
   leading up to it) to [bindings/not-in-linux.txt].
-- If your vendor prefix is not yet in [vendor-prefixes.txt], make sure to add
+- If your vendor prefix is not yet in [vendor-prefixes.yaml], make sure to add
   it as soon as possible to avoid collisions and inconsistencies.
 - Make a pull request
 
@@ -43,7 +43,7 @@ exchanged between Linux and this repository without issues.
 [dt]: https://www.devicetree.org/
 [bindings directory]: bindings
 [linux-bindings]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/devicetree/bindings
-[vendor-prefixes.txt]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/devicetree/bindings/vendor-prefixes.txt
+[vendor-prefixes.yaml]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/devicetree/bindings/vendor-prefixes.yaml
 [a script]: scripts/check-against-linux.py
 [Travis-CI]: https://travis-ci.org/riscv/riscv-device-tree-doc
 [GPLv2]: GPL-2.0.license


### PR DESCRIPTION
all credit goes to @OrichalcumCosmonaut in https://github.com/riscv-non-isa/riscv-device-tree-doc/pull/9